### PR TITLE
Slight changes to Step 2 of Running Doxygen.

### DIFF
--- a/LaTeX.html
+++ b/LaTeX.html
@@ -274,7 +274,7 @@
 
 		<br>
 
-	        <p>2. On Linux just run the command <code>doxygen -g</code> (in the folder where the code is) to create a configuration file called Doxyfile, then run <code>doxygen Doxyfile</code> to generate the documentation. Open doxywizard. At the top of the doxywizard page, under “Specify the working directory from which doxygen will run”, select the pathway to the project you want to document.</p>
+		<p>2. On Linux just run the command <code>doxygen -g</code> (in the folder where the code is) to create a configuration file called Doxyfile, then run <code>doxygen Doxyfile</code> to generate the documentation. You can then run <code>sudo apt install doxygen-gui</code> to install the doxywizard GUI. Open doxywizard with the command <code>doxywizard</code>. At the top of the doxywizard page, under “Specify the working directory from which doxygen will run”, select the pathway to the project you want to document.</p>
 
 		<br>
 

--- a/LaTeX.html
+++ b/LaTeX.html
@@ -274,7 +274,7 @@
 
 		<br>
 
-		<p>2. On Linux just run the command <code>doxygen -g</code> (in the folder where the code is) to create a configuration file called Doxyfile, then run <code>doxygen Doxyfile</code> to generate the documentation. You can then run <code>sudo apt install doxygen-gui</code> to install the doxywizard GUI. Open doxywizard with the command <code>doxywizard</code>. At the top of the doxywizard page, under “Specify the working directory from which doxygen will run”, select the pathway to the project you want to document.</p>
+		<p>2. On Linux just run the command <code>doxygen -g</code> (in the folder where the code is) to create a configuration file called Doxyfile, then run <code>doxygen Doxyfile</code> to generate the documentation. If you want to use the GUI as described in the rest of this guide, you can run <code>sudo apt install doxygen-gui</code> to install the doxywizard GUI. Open doxywizard with the command <code>doxywizard</code>. At the top of the doxywizard page, under “Specify the working directory from which doxygen will run”, select the pathway to the project you want to document.</p>
 
 		<br>
 


### PR DESCRIPTION
Added "You can then run sudo apt install doxygen-gui to install the doxywizard GUI. Open doxywizard with the command doxywizard." into step 2 to make it clearer how to access doxywizard.